### PR TITLE
Some scripts that depend on the inventory

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -39,6 +39,7 @@ ensure baseevents
 
 # QBCore & Extra stuff
 ensure qb-core
+ensure qb-inventory
 ensure [qb]
 ensure [standalone]
 ensure [voice]


### PR DESCRIPTION
Some scripts that depend on the inventory
Doesn't work on server startup for example
qb-shops not working
You need to manually run the script when entering the server