### PR TITLE
fix: reverted server.cfg changes

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -5,10 +5,20 @@
 # | |__| | |_) | |___| (_) | | |  __/
 #  \___\_\____/ \_____\___/|_|  \___|
 
-# Only change the IP if you're using a server with multiple network interfaces, otherwise change the port only.
+## You CAN edit the following:
 {{serverEndpoints}}
+sv_maxclients {{maxClients}}
+set steam_webApiKey "none"
+sets tags "default, deployer, qbcore, qb-core"
 
-# Database connection string
+## You MAY edit the following:
+sv_licenseKey "{{svLicense}}"
+sv_hostname "{{serverName}} built with {{recipeName}} by {{recipeAuthor}}!"
+sets sv_projectName "[{{recipeName}}] {{serverName}}"
+sets sv_projectDesc "{{recipeDescription}}"
+sets locale "en-US" 
+load_server_icon myLogo.png
+set sv_enforceGameBuild 2372
 set mysql_connection_string "{{dbConnectionString}}"
 
 # Voice config
@@ -41,53 +51,10 @@ ensure [standalone]
 ensure [voice]
 ensure [defaultmaps]
 
-# This allows players to use scripthook-based plugins such as the legacy Lambda Menu.
-# Set this to 1 to allow scripthook. Do note that this does _not_ guarantee players won't be able to use external plugins.
-sv_scriptHookAllowed 0
-
-# Uncomment this and set a password to enable RCON. Make sure to change the password - it should look like rcon_password "YOURPASSWORD"
-#rcon_password ""
-
-# A comma-separated list of tags for your server.
-# For example:
-# - sets tags "drifting, cars, racing"
-# Or:
-# - sets tags "roleplay, military, tanks"
-sets tags "default, deployer, qbcore, qb-core"
-
-# A valid locale identifier for your server's primary language.
-# For example "en-US", "fr-CA", "nl-NL", "de-DE", "en-GB", "pt-BR"
-sets locale "root-AQ"
-# please DO replace root-AQ on the line ABOVE with a real language! :)
-
-# Set an optional server info and connecting banner image url.
-# Size doesn't matter, any banner sized image will be fine.
-#sets banner_detail "https://url.to/image.png"
-#sets banner_connecting "https://url.to/image.png"
-
-# Set your server's hostname. This is not usually shown anywhere in listings.
-sv_hostname "{{serverName}} built with {{recipeName}} by {{recipeAuthor}}"
-
-# Set your server's Project Name
-sets sv_projectName "[{{recipeName}}] {{serverName}}"
-
-# Set your server's Project Description
-sets sv_projectDesc "{{recipeDescription}}"
-
-# Nested configs!
-#exec server_internal.cfg
-
-# Loading a server icon (96x96 PNG file)
-load_server_icon myLogo.png
-
-# convars which can be used in scripts
-set temp_convar "hey world!"
-
-# Remove the `#` from the below line if you do not want your server to be listed in the server browser.
-# Do not edit it if you *do* want your server listed.
-#sv_master1 ""
-
 ## Permissions ##
+add_ace group.admin command allow # allow all commands
+add_ace group.admin command.quit deny # but don't allow quit
+{{addPrincipalsMaster}}
 
 # Resources
 add_ace resource.qb-core command allow # Allow qb-core to execute commands
@@ -96,24 +63,6 @@ add_ace resource.qb-core command allow # Allow qb-core to execute commands
 add_ace qbcore.god command allow # Allow all commands
 
 # Inheritance
-add_principal qbcore.god group.admin # Error proof
 add_principal qbcore.god qbcore.admin # Allow gods access to admin commands
 add_principal qbcore.admin qbcore.mod # Allow admins access to mod commands
 #add_principal identifier.{{principalMasterIdentifier}} qbcore.god <- doesn't exist yet, change the generated one below to qbcore.god
-{{addPrincipalsMaster}}
-
-# enable OneSync (required for server-side state awareness)
-set onesync on
-
-# Game Build
-set sv_enforceGameBuild 2372
-
-# Server player slot limit (see https://fivem.net/server-hosting for limits)
-sv_maxclients 48
-
-# Steam Web API key, if you want to use Steam authentication (https://steamcommunity.com/dev/apikey)
-# -> replace "" with the key
-set steam_webApiKey "none"
-
-# License key for your server (https://keymaster.fivem.net)
-sv_licenseKey "{{svLicense}}"


### PR DESCRIPTION
As discussed on discord, this revert brings back the old server.cfg format.  
This is the recommended lean file, and uses the placeholders to guarantee compatibility with zap servers.  
I also added the `group.admin` group/perms which was removed for some reason.