### PR TITLE
fix(cfg): add back group.admin inheritage

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -53,7 +53,7 @@ ensure [defaultmaps]
 
 ## Permissions ##
 add_ace group.admin command allow # allow all commands
-add_ace group.admin command.quit deny # but don't allow quit
+#add_principal identifier.{{principalMasterIdentifier}} qbcore.god <- doesn't exist yet, change the generated one below to qbcore.god
 {{addPrincipalsMaster}}
 
 # Resources
@@ -63,6 +63,6 @@ add_ace resource.qb-core command allow # Allow qb-core to execute commands
 add_ace qbcore.god command allow # Allow all commands
 
 # Inheritance
+add_principal qbcore.god group.admin # Allow gods access to the main admin group used to get all default permissions
 add_principal qbcore.god qbcore.admin # Allow gods access to admin commands
 add_principal qbcore.admin qbcore.mod # Allow admins access to mod commands
-#add_principal identifier.{{principalMasterIdentifier}} qbcore.god <- doesn't exist yet, change the generated one below to qbcore.god


### PR DESCRIPTION
Fixed the inheritage for qbcore.god so that it has access to everything and moved the comment to the right place to not get people confused