### PR TITLE
Fixes an issue where a database is set to REQUIRE_PRIMARY_KEYs

### DIFF
--- a/qbcore.sql
+++ b/qbcore.sql
@@ -132,9 +132,11 @@ CREATE TABLE IF NOT EXISTS `phone_invoices` (
 ) ENGINE=InnoDB AUTO_INCREMENT=1;
 
 CREATE TABLE IF NOT EXISTS `phone_gallery` (
-   `citizenid` VARCHAR(255) NOT NULL ,
-   `image` VARCHAR(255) NOT NULL ,
-   `date` timestamp NULL DEFAULT current_timestamp()
+   `id` int(11) NOT NULL AUTO_INCREMENT,
+   `citizenid` VARCHAR(255) NOT NULL,
+   `image` VARCHAR(255) NOT NULL,
+   `date` timestamp NULL DEFAULT current_timestamp(),
+   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `player_mails` (


### PR DESCRIPTION
Was deploying to a DigitalOcean Managed Database for MySQL 8 and experience an issue where you could not proceed with script due to the db blocking the creation of tables without primary ids. I tracked this down to the phone gallery table creation.